### PR TITLE
Add duplicate and retrieval tests

### DIFF
--- a/src/AktieKoll.Tests/InsiderTradeServiceTests.cs
+++ b/src/AktieKoll.Tests/InsiderTradeServiceTests.cs
@@ -40,4 +40,89 @@ public class InsiderTradeServiceTests
         var saved = await ctx.InsiderTrades.ToListAsync();
         Assert.Single(saved);
     }
+
+    [Fact]
+    public async Task AddInsiderTrades_Duplicate_DoesNotAdd()
+    {
+        var ctx = CreateContext();
+        var service = new InsiderTradeService(ctx);
+        var trade = new InsiderTrade
+        {
+            CompanyName = "FooCorp",
+            InsiderName = "Alice",
+            Position = "CFO",
+            TransactionType = "Buy",
+            Date = DateTime.Today
+        };
+        ctx.InsiderTrades.Add(trade);
+        await ctx.SaveChangesAsync();
+
+        var result = await service.AddInsiderTrades(new List<InsiderTrade> { trade });
+
+        Assert.Equal("No new data was added.", result);
+        var count = await ctx.InsiderTrades.CountAsync();
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public async Task AddInsiderTrades_StopAtFirstDuplicate()
+    {
+        var ctx = CreateContext();
+        var service = new InsiderTradeService(ctx);
+
+        var existing = new InsiderTrade
+        {
+            CompanyName = "FooCorp",
+            InsiderName = "Alice",
+            Position = "CFO",
+            TransactionType = "Buy",
+            Date = DateTime.Today
+        };
+        ctx.InsiderTrades.Add(existing);
+        await ctx.SaveChangesAsync();
+
+        var newTrade = new InsiderTrade
+        {
+            CompanyName = "BarCorp",
+            InsiderName = "Bob",
+            Position = "CEO",
+            TransactionType = "Sell",
+            Date = DateTime.Today
+        };
+
+        var laterTrade = new InsiderTrade
+        {
+            CompanyName = "BazCorp",
+            InsiderName = "Cara",
+            Position = "CIO",
+            TransactionType = "Buy",
+            Date = DateTime.Today
+        };
+
+        var trades = new List<InsiderTrade> { newTrade, existing, laterTrade };
+
+        var result = await service.AddInsiderTrades(trades);
+
+        Assert.Equal("1 new trades added.", result);
+        var saved = await ctx.InsiderTrades.ToListAsync();
+        Assert.Equal(2, saved.Count);
+        Assert.Contains(saved, t => t.CompanyName == "BarCorp");
+        Assert.DoesNotContain(saved, t => t.CompanyName == "BazCorp");
+    }
+
+    [Fact]
+    public async Task GetInsiderTrades_ReturnsAllTrades()
+    {
+        var ctx = CreateContext();
+        ctx.InsiderTrades.AddRange(
+            new InsiderTrade { CompanyName = "FooCorp", InsiderName = "Alice", Position = "CFO", TransactionType = "Buy", Date = DateTime.Today },
+            new InsiderTrade { CompanyName = "BarCorp", InsiderName = "Bob", Position = "CEO", TransactionType = "Sell", Date = DateTime.Today }
+        );
+        await ctx.SaveChangesAsync();
+        var service = new InsiderTradeService(ctx);
+
+        var result = await service.GetInsiderTrades();
+
+        Assert.Equal(2, result.Count());
+    }
 }


### PR DESCRIPTION
## Summary
- extend InsiderTradeServiceTests to include duplicate handling tests
- add coverage for GetInsiderTrades

## Testing
- `dotnet test src/AktieKoll.Tests/AktieKoll.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684026ab34108332b47767127db4ddbb