### PR TITLE
Add Renovate bot workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,21 @@
+name: Renovate
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 1'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Run Renovate
+        uses: renovatebot/github-action@v40.1.10
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["config:base"]
+}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run Renovate bot
- configure Renovate with base settings

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68473e6b10ec83329d029b14e01ffbd0