### PR TITLE
Refactor trade controller to return dto

### DIFF
--- a/src/AktieKoll.Tests/Integration/Controllers/InsiderTradeControllerTests.cs
+++ b/src/AktieKoll.Tests/Integration/Controllers/InsiderTradeControllerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net;
 using AktieKoll.Data;
+using AktieKoll.Dtos;
 using AktieKoll.Models;
 using AktieKoll.Tests.Fixture;
 using AktieKoll.Tests.Integration.TestHelpers;
@@ -38,50 +39,6 @@ public class InsiderTradeControllerTests(WebApplicationFactoryFixture factory) :
             TransactionDate = publishingDate ?? DateTime.Today
         };
 
-    // GET /api/insidertrade
-    [Fact]
-    public async Task GetInsiderTrades_EmptyDatabase_ReturnsOkWithEmptyArray()
-    {
-        // Act
-        var response = await Client.GetTestAsync("/api/insidertrades");
-
-        // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-
-        var trades = await response.Content.ReadFromJsonTestAsync<List<InsiderTrade>>();
-        trades.Should().BeEmpty();
-    }
-
-    [Fact]
-    public async Task GetInsiderTrades_WithTrades_ReturnsAllTrades()
-    {
-        // Arrange
-        await SeedTradesAsync(
-            MakeTrade("Volvo"),
-            MakeTrade("Ericsson")
-        );
-
-        // Act
-        var response = await Client.GetTestAsync("/api/insidertrades");
-
-        // Assert
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-
-        var trades = await response.Content.ReadFromJsonTestAsync<List<InsiderTrade>>();
-        trades.Should().HaveCount(2);
-    }
-
-    [Fact]
-    public async Task GetInsiderTrades_ReturnsJsonContentType()
-    {
-        // Act
-        var response = await Client.GetTestAsync("/api/insidertrades");
-
-        // Assert
-        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
-    }
-
-
     // GET /api/insidertrade/page
     [Fact]
     public async Task GetInsiderTradesPage_DefaultParams_ReturnsFirstPage()
@@ -99,7 +56,7 @@ public class InsiderTradeControllerTests(WebApplicationFactoryFixture factory) :
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var trades = await response.Content.ReadFromJsonTestAsync<List<InsiderTrade>>();
+        var trades = await response.Content.ReadFromJsonTestAsync<List<InsiderTradeListDto>>();
         trades.Should().NotBeEmpty();
     }
 
@@ -121,7 +78,7 @@ public class InsiderTradeControllerTests(WebApplicationFactoryFixture factory) :
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var trades = await response.Content.ReadFromJsonTestAsync<List<InsiderTrade>>();
+        var trades = await response.Content.ReadFromJsonTestAsync<List<InsiderTradeListDto>>();
         trades.Should().HaveCount(2);
     }
 
@@ -141,8 +98,8 @@ public class InsiderTradeControllerTests(WebApplicationFactoryFixture factory) :
         var page2 = await Client.GetTestAsync("/api/insidertrades/page?page=2&pageSize=2");
 
         // Assert
-        var trades1 = await page1.Content.ReadFromJsonTestAsync<List<InsiderTrade>>();
-        var trades2 = await page2.Content.ReadFromJsonTestAsync<List<InsiderTrade>>();
+        var trades1 = await page1.Content.ReadFromJsonTestAsync<List<InsiderTradeListDto>>();
+        var trades2 = await page2.Content.ReadFromJsonTestAsync<List<InsiderTradeListDto>>();
 
         trades1.Should().HaveCount(2);
         trades2.Should().HaveCount(2);
@@ -198,7 +155,7 @@ public class InsiderTradeControllerTests(WebApplicationFactoryFixture factory) :
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var trades = await response.Content.ReadFromJsonTestAsync<List<InsiderTrade>>();
+        var trades = await response.Content.ReadFromJsonTestAsync<List<InsiderTradeListDto>>();
         trades.Should().NotBeEmpty();
         trades![0].CompanyName.Should().Be("BigCorp");
     }
@@ -333,7 +290,7 @@ public class InsiderTradeControllerTests(WebApplicationFactoryFixture factory) :
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var trades = await response.Content.ReadFromJsonTestAsync<List<InsiderTrade>>();
+        var trades = await response.Content.ReadFromJsonTestAsync<List<InsiderTradeListDto>>();
         trades.Should().HaveCount(1);
         trades![0].CompanyName.Should().Be("Volvo");
     }
@@ -366,7 +323,7 @@ public class InsiderTradeControllerTests(WebApplicationFactoryFixture factory) :
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        var trades = await response.Content.ReadFromJsonTestAsync<List<InsiderTrade>>();
+        var trades = await response.Content.ReadFromJsonTestAsync<List<InsiderTradeListDto>>();
         trades.Should().HaveCount(2);
     }
 
@@ -386,8 +343,8 @@ public class InsiderTradeControllerTests(WebApplicationFactoryFixture factory) :
         var page2 = await Client.GetTestAsync("/api/insidertrades/company?name=Volvo&skip=2&take=2");
 
         // Assert
-        var trades1 = await page1.Content.ReadFromJsonTestAsync<List<InsiderTrade>>();
-        var trades2 = await page2.Content.ReadFromJsonTestAsync<List<InsiderTrade>>();
+        var trades1 = await page1.Content.ReadFromJsonTestAsync<List<InsiderTradeListDto>>();
+        var trades2 = await page2.Content.ReadFromJsonTestAsync<List<InsiderTradeListDto>>();
 
         trades1.Should().HaveCount(2);
         trades2.Should().HaveCount(2);

--- a/src/AktieKoll.Tests/Integration/Services/TransactionsDbTests.cs
+++ b/src/AktieKoll.Tests/Integration/Services/TransactionsDbTests.cs
@@ -48,7 +48,7 @@ public class TransactionsDbTests
 
         await service.AddInsiderTrades(trades);
 
-        var result = await service.GetInsiderTrades();
+        var result = await service.GetInsiderTradesPage(1, 100);
 
         await Verify(result);
     }
@@ -139,7 +139,7 @@ public class TransactionsDbTests
 
         await service.AddInsiderTrades(trades);
 
-        var result = await service.GetInsiderTrades();
+        var result = await service.GetInsiderTradesPage(1, 100);
 
         await Verify(result);
     }
@@ -158,7 +158,7 @@ public class TransactionsDbTests
         var service = ServiceTestHelpers.CreateInsiderTradeService(ctx);
         await service.AddInsiderTrades(trades);
 
-        var result = await service.GetInsiderTrades();
+        var result = await service.GetInsiderTradesPage(1, 100);
 
         await Verify(result);
     }
@@ -195,7 +195,7 @@ public class TransactionsDbTests
 
         await service.AddInsiderTrades(trades);
 
-        var result = await service.GetInsiderTrades();
+        var result = await service.GetInsiderTradesPage(1, 100);
 
         await Verify(result);
     }
@@ -219,7 +219,7 @@ public class TransactionsDbTests
 
         await service.AddInsiderTrades(trades);
 
-        var result = await service.GetInsiderTrades();
+        var result = await service.GetInsiderTradesPage(1, 100);
 
         await Verify(result);
     }
@@ -278,7 +278,7 @@ public class TransactionsDbTests
 
         await service.AddInsiderTrades(trades);
 
-        var result = await service.GetInsiderTrades();
+        var result = await service.GetInsiderTradesPage(1, 100);
 
         await Verify(result);
     }

--- a/src/AktieKoll.Tests/Unit/InsiderTradeServiceTests.cs
+++ b/src/AktieKoll.Tests/Unit/InsiderTradeServiceTests.cs
@@ -190,7 +190,7 @@ public class InsiderTradeServiceTests
         await ctx.SaveChangesAsync(TestContext.Current.CancellationToken);
         var service = ServiceTestHelpers.CreateInsiderTradeService(ctx);
 
-        var result = await service.GetInsiderTrades();
+        var result = await service.GetInsiderTradesPage(1, 100);
 
         Assert.Equal(2, result.Count());
     }

--- a/src/AktieKoll/Controllers/InsiderTradesController.cs
+++ b/src/AktieKoll/Controllers/InsiderTradesController.cs
@@ -1,4 +1,6 @@
-﻿using AktieKoll.Interfaces;
+﻿using AktieKoll.Dtos;
+using AktieKoll.Extensions;
+using AktieKoll.Interfaces;
 using AktieKoll.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
@@ -10,30 +12,27 @@ namespace AktieKoll.Controllers;
 [EnableRateLimiting("api")]
 public class InsiderTradesController(IInsiderTradeService tradeService) : ControllerBase
 {
-
-    [HttpGet]
-    public async Task<ActionResult<IEnumerable<InsiderTrade>>> GetInsiderTrades()
-    {
-        var trades = await tradeService.GetInsiderTrades();
-        return Ok(trades);
-    }
-
     [HttpGet("page")]
-    public async Task<ActionResult<IEnumerable<InsiderTrade>>> GetInsiderTradesPage([FromQuery] int page = 1, [FromQuery] int pageSize = 10)
+    public async Task<ActionResult<IEnumerable<InsiderTradeListDto>>> GetInsiderTradesPage([FromQuery] int page = 1, [FromQuery] int pageSize = 10)
     {
         if (page < 1 || pageSize < 1)
         {
             return BadRequest("Page and page size must be greater than zero.");
         }
+
         var trades = await tradeService.GetInsiderTradesPage(page, pageSize);
-        return Ok(trades);
+        var dtos = trades.Select(t => t.ToListDto());
+
+        return Ok(dtos);
     }
 
     [HttpGet("top")]
-    public async Task<ActionResult<IEnumerable<InsiderTrade>>> GetInsiderTradesTop()
+    public async Task<ActionResult<IEnumerable<InsiderTradeListDto>>> GetInsiderTradesTop()
     {
         var trades = await tradeService.GetInsiderTradesTop();
-        return Ok(trades);
+        var dtos = trades.Select(t => t.ToListDto());
+
+        return Ok(dtos);
     }
 
     [HttpGet("count-buy")]
@@ -57,7 +56,7 @@ public class InsiderTradesController(IInsiderTradeService tradeService) : Contro
     }
 
     [HttpGet("company")]
-    public async Task<ActionResult<IEnumerable<InsiderTrade>>> GetByCompanyName(
+    public async Task<ActionResult<IEnumerable<InsiderTradeListDto>>> GetByCompanyName(
         [FromQuery] string name,
         [FromQuery] int skip = 0,
         [FromQuery] int take = 10)
@@ -69,6 +68,8 @@ public class InsiderTradesController(IInsiderTradeService tradeService) : Contro
             return NotFound(new { error = $"No trades found for company: {name}" });
         }
 
-        return Ok(trades);
+        var dtos = trades.Select(t => t.ToListDto());
+
+        return Ok(dtos);
     }
 }

--- a/src/AktieKoll/Dtos/InsiderTradeListDto.cs
+++ b/src/AktieKoll/Dtos/InsiderTradeListDto.cs
@@ -1,0 +1,15 @@
+﻿namespace AktieKoll.Dtos;
+
+public record InsiderTradeListDto
+{
+    public required string CompanyName { get; init; }
+    public required string InsiderName { get; init; }
+    public string? Position { get; init; }
+    public required string TransactionType { get; init; }
+    public required int Shares { get; init; }
+    public required decimal Price { get; init; }
+    public required string Currency { get; init; }
+    public string? Symbol { get; init; }
+    public required DateTime PublishingDate { get; init; }
+    public required DateTime TransactionDate { get; init; }
+}

--- a/src/AktieKoll/Extensions/InsiderTradeExtensions.cs
+++ b/src/AktieKoll/Extensions/InsiderTradeExtensions.cs
@@ -1,4 +1,5 @@
-﻿using AktieKoll.Models;
+﻿using AktieKoll.Dtos;
+using AktieKoll.Models;
 
 namespace AktieKoll.Extensions;
 
@@ -17,4 +18,21 @@ public static class InsiderTradeExtensions
 
     public static bool IsRevised(this InsiderTrade trade)
         => string.Equals(trade.Status, "Reviderad", StringComparison.OrdinalIgnoreCase);
+
+    public static InsiderTradeListDto ToListDto(this InsiderTrade trade)
+    {
+        return new InsiderTradeListDto
+        {
+            CompanyName = trade.CompanyName,
+            InsiderName = trade.InsiderName,
+            Position = trade.Position,
+            TransactionType = trade.TransactionType,
+            Shares = trade.Shares,
+            Price = trade.Price,
+            Currency = trade.Currency,
+            Symbol = trade.Symbol,
+            PublishingDate = trade.PublishingDate,
+            TransactionDate = trade.TransactionDate
+        };
+    }
 }

--- a/src/AktieKoll/Interfaces/IInsiderTrades.cs
+++ b/src/AktieKoll/Interfaces/IInsiderTrades.cs
@@ -5,7 +5,6 @@ namespace AktieKoll.Interfaces;
 public interface IInsiderTradeService
 {
     Task<string> AddInsiderTrades(List<InsiderTrade> insiderTrades);
-    Task<IEnumerable<InsiderTrade>> GetInsiderTrades();
     Task<IEnumerable<InsiderTrade>> GetInsiderTradesPage(int page, int pageSize);
     Task<IEnumerable<InsiderTrade>> GetInsiderTradesTop();
     Task<IEnumerable<CompanyTransactionStats>> GetTransactionCountBuy(string? companyName = null, int days = 30, int? top = 5);

--- a/src/AktieKoll/Services/InsiderTradeService.cs
+++ b/src/AktieKoll/Services/InsiderTradeService.cs
@@ -67,13 +67,6 @@ public class InsiderTradeService(ApplicationDbContext context, ISymbolService sy
 
     }
 
-    public async Task<IEnumerable<InsiderTrade>> GetInsiderTrades()
-    {
-        return await context.InsiderTrades
-            .OrderByDescending(t => t.PublishingDate)
-            .ToListAsync();
-    }
-
     public async Task<IEnumerable<InsiderTrade>> GetInsiderTradesPage(int page, int pageSize)
     {
         var skip = (page - 1) * pageSize;
@@ -104,12 +97,12 @@ public class InsiderTradeService(ApplicationDbContext context, ISymbolService sy
 
         var query = context.InsiderTrades
             .Where(t => t.PublishingDate >= startDate && t.PublishingDate < endDate)
-            .Where(t => t.TransactionType.Equals(transactionType, StringComparison.OrdinalIgnoreCase));
+            .Where(t => t.TransactionType.ToLower() == transactionType.ToLower());
 
         if (!string.IsNullOrWhiteSpace(companyName))
         {
-            var filtered = companyName.FilterCompanyName();
-            query = query.Where(t => t.CompanyName.Equals(filtered, StringComparison.OrdinalIgnoreCase));
+            var filtered = companyName.FilterCompanyName().ToLower();
+            query = query.Where(t => t.CompanyName.ToLower() == filtered);
         }
 
         var grouped = query
@@ -131,9 +124,9 @@ public class InsiderTradeService(ApplicationDbContext context, ISymbolService sy
     }
 
     public Task<IEnumerable<CompanyTransactionStats>> GetTransactionCountBuy(string? companyName, int days = 30, int? top = 5)
-        => GetTransactionCountByType("Förvärv", companyName, days, top);
+        => GetTransactionCountByType("förvärv", companyName, days, top);
     public Task<IEnumerable<CompanyTransactionStats>> GetTransactionCountSell(string? companyName, int days = 30, int? top = 5)
-        => GetTransactionCountByType("Avyttring", companyName, days, top);
+        => GetTransactionCountByType("avyttring", companyName, days, top);
 
     public async Task<IEnumerable<InsiderTrade>> GetInsiderTradesByCompany(string companyName, int skip = 0, int take = 10)
     {
@@ -142,10 +135,10 @@ public class InsiderTradeService(ApplicationDbContext context, ISymbolService sy
             return [];
         }
 
-        var filteredCompanyName = companyName.FilterCompanyName();
+        var filteredCompanyName = companyName.FilterCompanyName().ToLower();
 
         return await context.InsiderTrades
-            .Where(t => t.CompanyName.Equals(filteredCompanyName, StringComparison.OrdinalIgnoreCase))
+            .Where(t => t.CompanyName.ToLower() == filteredCompanyName)
             .OrderByDescending(t => t.PublishingDate)
             .Skip(skip)
             .Take(take)


### PR DESCRIPTION
Refactored InsiderTradeController to return DTO instead of model to get rid of unecessary data.
Removed GetAll trade endpoint unused and slow to query whole db and refactored tests to use Page endpoint instead of GetAllTrades.