### PR TITLE
symbol resolution overhaul with fuzzy matching and cache-backed lookup

### DIFF
--- a/src/AktieKoll.Tests/Integration/Services/TransactionsDbTests.AddNewCsvData_fromDate=2025-06-23_toDate=2025-06-24.verified.txt
+++ b/src/AktieKoll.Tests/Integration/Services/TransactionsDbTests.AddNewCsvData_fromDate=2025-06-23_toDate=2025-06-24.verified.txt
@@ -1,7 +1,7 @@
 ﻿[
   {
     Id: 1,
-    CompanyName: NORDIC LEVEL GROUP,
+    CompanyName: NORDIC LEVEL,
     InsiderName: Samir Taha,
     Position: Styrelseordförande,
     TransactionType: Förvärv,
@@ -15,7 +15,7 @@
   },
   {
     Id: 2,
-    CompanyName: Mysafety Group,
+    CompanyName: Mysafety,
     InsiderName: Marcus Pettersson Berver,
     Position: VD,
     TransactionType: Förvärv,
@@ -155,7 +155,7 @@
   },
   {
     Id: 12,
-    CompanyName: niutech Group,
+    CompanyName: niutech,
     InsiderName: Björn Rickard Olovsson,
     Position: Annan ledande befattningshavare,
     TransactionType: Tilldelning,
@@ -169,7 +169,7 @@
   },
   {
     Id: 13,
-    CompanyName: Niutech Group,
+    CompanyName: Niutech,
     InsiderName: Magnus Karlsson,
     Position: Annan ledande befattningshavare,
     TransactionType: Tilldelning,
@@ -393,7 +393,7 @@
   },
   {
     Id: 29,
-    CompanyName: Niutech Group,
+    CompanyName: Niutech,
     InsiderName: Mattias Leijon,
     Position: Styrelseledamot,
     TransactionType: Tilldelning,
@@ -435,7 +435,7 @@
   },
   {
     Id: 32,
-    CompanyName: Niutech Group,
+    CompanyName: Niutech,
     InsiderName: Klas Zetterman,
     Position: VD,
     TransactionType: Tilldelning,
@@ -449,7 +449,7 @@
   },
   {
     Id: 33,
-    CompanyName: Lyckegård Group,
+    CompanyName: Lyckegård,
     InsiderName: Anders Gösta Holm,
     Position: Styrelseordförande,
     TransactionType: Förvärv,
@@ -463,7 +463,7 @@
   },
   {
     Id: 34,
-    CompanyName: Lyckegård Group,
+    CompanyName: Lyckegård,
     InsiderName: Anders Gösta Holm,
     Position: Styrelseordförande,
     TransactionType: Förvärv,

--- a/src/AktieKoll.Tests/Integration/Services/TransactionsDbTests.GetTransactionCountBuy_ReturnsMostActive_companyName=null_top=3_days=365.verified.txt
+++ b/src/AktieKoll.Tests/Integration/Services/TransactionsDbTests.GetTransactionCountBuy_ReturnsMostActive_companyName=null_top=3_days=365.verified.txt
@@ -4,7 +4,7 @@
     TransactionCount: 8
   },
   {
-    CompanyName: Lyckegård Group,
+    CompanyName: Lyckegård,
     TransactionCount: 2
   },
   {

--- a/src/AktieKoll.Tests/Integration/Services/TransactionsDbTests.GetTransactionCountBuy_ReturnsMostActive_companyName=null_top=null_days=365.verified.txt
+++ b/src/AktieKoll.Tests/Integration/Services/TransactionsDbTests.GetTransactionCountBuy_ReturnsMostActive_companyName=null_top=null_days=365.verified.txt
@@ -4,7 +4,7 @@
     TransactionCount: 8
   },
   {
-    CompanyName: Lyckegård Group,
+    CompanyName: Lyckegård,
     TransactionCount: 2
   },
   {
@@ -28,11 +28,11 @@
     TransactionCount: 1
   },
   {
-    CompanyName: Mysafety Group,
+    CompanyName: Mysafety,
     TransactionCount: 1
   },
   {
-    CompanyName: NORDIC LEVEL GROUP,
+    CompanyName: NORDIC LEVEL,
     TransactionCount: 1
   },
   {

--- a/src/AktieKoll.Tests/Integration/Services/TransactionsDbTests.cs
+++ b/src/AktieKoll.Tests/Integration/Services/TransactionsDbTests.cs
@@ -2,6 +2,7 @@
 using AktieKoll.Services;
 using AktieKoll.Tests.Extensions;
 using AktieKoll.Tests.Shared.TestHelpers;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
 using static AktieKoll.Extensions.CsvDtoExtensions;
@@ -399,7 +400,8 @@ public class TransactionsDbTests
         await ctx.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var logger = NullLogger<SymbolService>.Instance;
-        var symbolService = new SymbolService(ctx, logger);
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var symbolService = new SymbolService(ctx, cache, logger);
 
         var trades = new List<InsiderTrade>
         {
@@ -440,7 +442,9 @@ public class TransactionsDbTests
         await ctx.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var logger = NullLogger<SymbolService>.Instance;
-        var symbolService = new SymbolService(ctx, logger);
+        var cache = new MemoryCache(new MemoryCacheOptions());
+
+        var symbolService = new SymbolService(ctx, cache, logger);
 
         var trades = new List<InsiderTrade>
         {
@@ -484,7 +488,8 @@ public class TransactionsDbTests
         await ctx.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var logger = NullLogger<SymbolService>.Instance;
-        var symbolService = new SymbolService(ctx, logger);
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var symbolService = new SymbolService(ctx, cache,logger);
 
         var trades = new List<InsiderTrade>
     {
@@ -525,7 +530,8 @@ public class TransactionsDbTests
         await ctx.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var logger = NullLogger<SymbolService>.Instance;
-        var symbolService = new SymbolService(ctx, logger);
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var symbolService = new SymbolService(ctx, cache, logger);
 
         var trades = new List<InsiderTrade>
     {
@@ -567,7 +573,8 @@ public class TransactionsDbTests
         await ctx.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         var logger = NullLogger<SymbolService>.Instance;
-        var symbolService = new SymbolService(ctx, logger);
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var symbolService = new SymbolService(ctx, cache, logger);
 
         var trades = new List<InsiderTrade>
     {

--- a/src/AktieKoll.Tests/Shared/TestHelpers/ServiceTestHelpers.cs
+++ b/src/AktieKoll.Tests/Shared/TestHelpers/ServiceTestHelpers.cs
@@ -17,18 +17,24 @@ public static class ServiceTestHelpers
         return new ApplicationDbContext(options);
     }
 
+    public static SymbolService CreateSymbolService(ApplicationDbContext ctx, IMemoryCache? cache = null)
+    {
+        return new SymbolService(ctx, cache ?? new MemoryCache(new MemoryCacheOptions()), NullLogger<SymbolService>.Instance);
+    }
+
     public static InsiderTradeService CreateInsiderTradeService(ApplicationDbContext ctx, TimeProvider? timeProvider = null)
     {
-        var logger = NullLogger<SymbolService>.Instance;
-        var symbolService = new SymbolService(ctx, logger);
+        var symbolService = CreateSymbolService(ctx);
         var cache = new MemoryCache(new MemoryCacheOptions());
+        var tradeLogger = NullLogger<InsiderTradeService>.Instance;
+
         
-        return new InsiderTradeService(ctx, symbolService, cache, timeProvider ?? TimeProvider.System);
+        return new InsiderTradeService(ctx, symbolService, cache, timeProvider ?? TimeProvider.System, tradeLogger);
     }
 
     public static async Task SeedCompanies(
-    ApplicationDbContext ctx,
-    params (string Isin, string Code)[] companies)
+        ApplicationDbContext ctx,
+        params (string Isin, string Code)[] companies)
     {
         var converted = companies
             .Select(c => (Isin: (string?)c.Isin, c.Code, Name: (string?)null))

--- a/src/AktieKoll.Tests/Unit/CsvFetchServiceTests.GetTransactionsFiltered_fromDate=2025-01-01_toDate=2025-01-02.verified.txt
+++ b/src/AktieKoll.Tests/Unit/CsvFetchServiceTests.GetTransactionsFiltered_fromDate=2025-01-01_toDate=2025-01-02.verified.txt
@@ -1,6 +1,6 @@
 ﻿[
   {
-    CompanyName: Balco Group,
+    CompanyName: Balco,
     InsiderName: Ingalill Berglund,
     Position: Styrelseordförande,
     TransactionType: Förvärv,
@@ -13,7 +13,7 @@
     TransactionDate: DateTime_2
   },
   {
-    CompanyName: Balco Group,
+    CompanyName: Balco,
     InsiderName: Ingalill Berglund,
     Position: Styrelseordförande,
     TransactionType: Förvärv,
@@ -52,7 +52,7 @@
     TransactionDate: DateTime_6
   },
   {
-    CompanyName: Dynavox Group,
+    CompanyName: Dynavox,
     InsiderName: Linda Tybring,
     Position: CFO,
     TransactionType: Förvärv,
@@ -64,7 +64,7 @@
     TransactionDate: DateTime_2
   },
   {
-    CompanyName: Dynavox Group,
+    CompanyName: Dynavox,
     InsiderName: Linda Tybring,
     Position: CFO,
     TransactionType: Avyttring,
@@ -116,7 +116,7 @@
     TransactionDate: DateTime_2
   },
   {
-    CompanyName: Dynavox Group,
+    CompanyName: Dynavox,
     InsiderName: Tara Ann Rudnicki,
     Position: Annan ledande befattningshavare,
     TransactionType: Förvärv,
@@ -322,7 +322,7 @@
     TransactionDate: DateTime_6
   },
   {
-    CompanyName: Nelly Group,
+    CompanyName: Nelly,
     InsiderName: Lotta Fermén,
     Position: Ledningsgrupp,
     TransactionType: Tilldelning,

--- a/src/AktieKoll.Tests/Unit/CsvFetchServiceTests.GetTransactionsWithSymbolResolution_fromDate=2025-01-01_toDate=2025-01-02.verified.txt
+++ b/src/AktieKoll.Tests/Unit/CsvFetchServiceTests.GetTransactionsWithSymbolResolution_fromDate=2025-01-01_toDate=2025-01-02.verified.txt
@@ -4,7 +4,7 @@
   TradesWithoutSymbols: 6,
   trades: [
     {
-      CompanyName: Balco Group,
+      CompanyName: Balco,
       InsiderName: Ingalill Berglund,
       Position: Styrelseordförande,
       TransactionType: Förvärv,
@@ -18,7 +18,7 @@
       TransactionDate: DateTime_2
     },
     {
-      CompanyName: Balco Group,
+      CompanyName: Balco,
       InsiderName: Ingalill Berglund,
       Position: Styrelseordförande,
       TransactionType: Förvärv,
@@ -60,7 +60,7 @@
       TransactionDate: DateTime_6
     },
     {
-      CompanyName: Dynavox Group,
+      CompanyName: Dynavox,
       InsiderName: Linda Tybring,
       Position: CFO,
       TransactionType: Förvärv,
@@ -73,7 +73,7 @@
       TransactionDate: DateTime_2
     },
     {
-      CompanyName: Dynavox Group,
+      CompanyName: Dynavox,
       InsiderName: Linda Tybring,
       Position: CFO,
       TransactionType: Avyttring,
@@ -129,7 +129,7 @@
       TransactionDate: DateTime_2
     },
     {
-      CompanyName: Dynavox Group,
+      CompanyName: Dynavox,
       InsiderName: Tara Ann Rudnicki,
       Position: Annan ledande befattningshavare,
       TransactionType: Förvärv,
@@ -349,7 +349,7 @@
       TransactionDate: DateTime_6
     },
     {
-      CompanyName: Nelly Group,
+      CompanyName: Nelly,
       InsiderName: Lotta Fermén,
       Position: Ledningsgrupp,
       TransactionType: Tilldelning,

--- a/src/AktieKoll.Tests/Unit/CsvFetchServiceTests.cs
+++ b/src/AktieKoll.Tests/Unit/CsvFetchServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿using AktieKoll.Services;
 using AktieKoll.Tests.Shared.TestHelpers;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging.Abstractions;
 using static AktieKoll.Extensions.CsvDtoExtensions;
 
@@ -66,7 +67,8 @@ public class CsvFetchServiceTests
                                    .GetRequiredService<CsvFetchService>(services => services.AuthorizedClient());
 
         var logger = NullLogger<SymbolService>.Instance;
-        var symbolService = new SymbolService(ctx, logger);
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var symbolService = new SymbolService(ctx, cache,logger);
 
         var csvResult = await csvFetchService.FetchInsiderTradesAsync(fromDate, toDate);
         var trades = InsiderTradeMapper.MapDtosToTrades(csvResult);

--- a/src/AktieKoll.Tests/Unit/SymbolServiceTests.cs
+++ b/src/AktieKoll.Tests/Unit/SymbolServiceTests.cs
@@ -1,0 +1,245 @@
+﻿using AktieKoll.Models;
+using AktieKoll.Tests.Shared.TestHelpers;
+
+namespace AktieKoll.Tests.Unit;
+
+public class SymbolServiceTests
+{
+    // ── ISIN exact ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ResolveSymbol_IsinExact_VolvoB()
+    {
+        var ctx = ServiceTestHelpers.CreateContext();
+        await ServiceTestHelpers.SeedCompanies(ctx,
+            (Isin: "SE0000115446", Code: "VOLV-B", Name: "Volvo B"),
+            (Isin: "SE0000115420", Code: "VOLV-A", Name: "Volvo A"));
+
+        var svc = ServiceTestHelpers.CreateSymbolService(ctx);
+
+        var symbol = await svc.ResolveSymbolAsync("AB Volvo (publ)", "SE0000115446");
+
+        Assert.Equal("VOLV-B", symbol);
+    }
+
+    [Fact]
+    public async Task ResolveSymbol_IsinExact_VolvoCar()
+    {
+        var ctx = ServiceTestHelpers.CreateContext();
+        await ServiceTestHelpers.SeedCompanies(ctx,
+            (Isin: "SE0021628898", Code: "VOLCAR-B", Name: "Volvo Car B"));
+
+        var svc = ServiceTestHelpers.CreateSymbolService(ctx);
+
+        var symbol = await svc.ResolveSymbolAsync("Volvo Car", "SE0021628898");
+
+        Assert.Equal("VOLCAR-B", symbol);
+    }
+
+    // ── ISIN fuzzy (strip spaces/dashes) ──────────────────────────────────────
+
+    [Fact]
+    public async Task ResolveSymbol_IsinFuzzy_NormalisedMatch()
+    {
+        var ctx = ServiceTestHelpers.CreateContext();
+        await ServiceTestHelpers.SeedCompanies(ctx,
+            (Isin: "SE0000115446", Code: "VOLV-B", Name: "Volvo B"));
+
+        var svc = ServiceTestHelpers.CreateSymbolService(ctx);
+
+        // Trade ISIN has a stray space — fuzzy normalisation should still match
+        var symbol = await svc.ResolveSymbolAsync("Volvo", "SE 0000115446");
+
+        Assert.Equal("VOLV-B", symbol);
+    }
+
+    // ── Name fuzzy (Jaccard) ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ResolveSymbol_NameFuzzy_AktiebolagetVolvo_ResolvesViaJaccard()
+    {
+        var ctx = ServiceTestHelpers.CreateContext();
+        await ServiceTestHelpers.SeedCompanies(ctx,
+            (Isin: "SE0000115420", Code: "VOLV-A", Name: "AB Volvo (publ)"),
+            (Isin: "SE0000115446", Code: "VOLV-B", Name: "AB Volvo (publ)"));
+
+        var svc = ServiceTestHelpers.CreateSymbolService(ctx);
+
+        var symbol = await svc.ResolveSymbolAsync("Aktiebolaget Volvo", null);
+
+        // Should resolve to VOLV-A or VOLV-B (B preferred)
+        Assert.NotNull(symbol);
+        Assert.True(symbol == "VOLV-A" || symbol == "VOLV-B");
+    }
+
+    // ── Unresolved ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ResolveSymbol_UnknownNameAndWrongIsin_ReturnsNull()
+    {
+        var ctx = ServiceTestHelpers.CreateContext();
+        await ServiceTestHelpers.SeedCompanies(ctx,
+            (Isin: "SE0000115446", Code: "VOLV-B", Name: "Volvo B"));
+
+        var svc = ServiceTestHelpers.CreateSymbolService(ctx);
+
+        var symbol = await svc.ResolveSymbolAsync("XyzUnknownCorp Ltd", "XX9999999999");
+
+        Assert.Null(symbol);
+    }
+
+    // ── B share preferred over A share ────────────────────────────────────────
+
+    [Fact]
+    public async Task ResolveSymbol_BSharePreferredOverAShare()
+    {
+        var ctx = ServiceTestHelpers.CreateContext();
+        await ServiceTestHelpers.SeedCompanies(ctx,
+            (Isin: null, Code: "ERIC-A", Name: "Telefonaktiebolaget LM Ericsson (publ)"),
+            (Isin: null, Code: "ERIC-B", Name: "Telefonaktiebolaget LM Ericsson (publ)"));
+
+        var svc = ServiceTestHelpers.CreateSymbolService(ctx);
+
+        // Both ERIC-A and ERIC-B normalise to "ericsson" — B must win
+        var symbol = await svc.ResolveSymbolAsync("Telefonaktiebolaget LM Ericsson (publ)", null);
+
+        Assert.Equal("ERIC-B", symbol);
+    }
+
+    // ── Batch resolve ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ResolveSymbolsAsync_StampsSymbolOnTrades()
+    {
+        var ctx = ServiceTestHelpers.CreateContext();
+        await ServiceTestHelpers.SeedCompanies(ctx,
+            (Isin: "SE0000115446", Code: "VOLV-B", Name: "Volvo B"));
+
+        var svc = ServiceTestHelpers.CreateSymbolService(ctx);
+
+        var trades = new List<InsiderTrade>
+        {
+            new()
+            {
+                CompanyName = "Volvo",
+                InsiderName = "Test",
+                TransactionType = "Förvärv",
+                Shares = 100,
+                Price = 50m,
+                Currency = "SEK",
+                Status = "Aktuell",
+                Isin = "SE0000115446",
+                PublishingDate = DateTime.Today,
+                TransactionDate = DateTime.Today
+            }
+        };
+
+        await svc.ResolveSymbolsAsync(trades);
+
+        Assert.Equal("VOLV-B", trades[0].Symbol);
+    }
+
+    // ── Cache invalidation ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ResolveSymbol_AfterInvalidate_PicksUpNewCompany()
+    {
+        var ctx = ServiceTestHelpers.CreateContext();
+        var svc = ServiceTestHelpers.CreateSymbolService(ctx);
+
+        // First call with empty DB
+        var before = await svc.ResolveSymbolAsync("Foo Corp", "SE0001");
+        Assert.Null(before);
+
+        // Add company, invalidate, retry
+        await ServiceTestHelpers.SeedCompanies(ctx,
+            (Isin: "SE0001", Code: "FOO", Name: "Foo Corp"));
+        svc.InvalidateCache();
+
+        var after = await svc.ResolveSymbolAsync("Foo Corp", "SE0001");
+        Assert.Equal("FOO", after);
+    }
+
+    [Fact]
+    public async Task ResolveSymbol_IsinFuzzy_DashInIsin_StillMatches()
+    {
+        var ctx = ServiceTestHelpers.CreateContext();
+        await ServiceTestHelpers.SeedCompanies(ctx,
+            (Isin: "SE0000115446", Code: "VOLV-B", Name: "Volvo B"));
+
+        var svc = ServiceTestHelpers.CreateSymbolService(ctx);
+
+        // Trade ISIN has dashes — fuzzy normalisation should still match
+        var symbol = await svc.ResolveSymbolAsync("Volvo", "SE-0000-115446");
+
+        Assert.Equal("VOLV-B", symbol);
+    }
+
+    [Fact]
+    public async Task ResolveSymbol_NullInputs_ReturnsNullWithoutThrowing()
+    {
+        var ctx = ServiceTestHelpers.CreateContext();
+        var svc = ServiceTestHelpers.CreateSymbolService(ctx);
+
+        var symbol = await svc.ResolveSymbolAsync(null, null);
+
+        Assert.Null(symbol);
+    }
+
+    [Fact]
+    public async Task ResolveSymbol_NameExact_StripsPublAndMatches()
+    {
+        var ctx = ServiceTestHelpers.CreateContext();
+        await ServiceTestHelpers.SeedCompanies(ctx,
+            (Isin: null, Code: "HM-B", Name: "Hennes & Mauritz AB (publ)"));
+
+        var svc = ServiceTestHelpers.CreateSymbolService(ctx);
+
+        // Input has no ISIN, slightly different format — should hit name_exact after normalise
+        var symbol = await svc.ResolveSymbolAsync("Hennes & Mauritz AB", null);
+
+        Assert.Equal("HM-B", symbol);
+    }
+
+    [Fact]
+    public async Task ResolveSymbol_IsinExact_WinsEvenWithWrongName()
+    {
+        var ctx = ServiceTestHelpers.CreateContext();
+        await ServiceTestHelpers.SeedCompanies(ctx,
+            (Isin: "SE0000115446", Code: "VOLV-B", Name: "AB Volvo (publ)"));
+
+        var svc = ServiceTestHelpers.CreateSymbolService(ctx);
+
+        // Name is wrong but ISIN is correct — should still resolve
+        var symbol = await svc.ResolveSymbolAsync("Completely Wrong Name", "SE0000115446");
+
+        Assert.Equal("VOLV-B", symbol);
+    }
+
+    // ── Already-resolved trades are skipped by batch method ──────────────────
+
+    [Fact]
+    public async Task ResolveSymbolsAsync_SkipsTradesWithExistingSymbol()
+    {
+        var ctx = ServiceTestHelpers.CreateContext();
+        var svc = ServiceTestHelpers.CreateSymbolService(ctx);
+
+        var trade = new InsiderTrade
+        {
+            CompanyName = "SomeCompany",
+            InsiderName = "Test",
+            TransactionType = "Förvärv",
+            Shares = 1,
+            Price = 1m,
+            Currency = "SEK",
+            Status = "Aktuell",
+            Symbol = "ALREADY",
+            PublishingDate = DateTime.Today,
+            TransactionDate = DateTime.Today
+        };
+
+        await svc.ResolveSymbolsAsync([trade]);
+
+        Assert.Equal("ALREADY", trade.Symbol);
+    }
+}

--- a/src/AktieKoll/Controllers/InsiderTradesController.cs
+++ b/src/AktieKoll/Controllers/InsiderTradesController.cs
@@ -10,9 +10,8 @@ namespace AktieKoll.Controllers;
 [ApiController]
 [Route("api/[controller]")]
 [EnableRateLimiting("api")]
-public class InsiderTradesController(IInsiderTradeService tradeService) : ControllerBase
+public class InsiderTradesController(IInsiderTradeService tradeService, ILogger<InsiderTradesController> logger) : ControllerBase
 {
-
     private const int MaxPageSize = 100;
 
     [HttpGet("page")]
@@ -79,7 +78,8 @@ public class InsiderTradesController(IInsiderTradeService tradeService) : Contro
 
     [HttpGet("company")]
     public async Task<ActionResult<IEnumerable<InsiderTradeListDto>>> GetByCompanyName(
-        [FromQuery] string name,
+        [FromQuery] string? symbol,
+        [FromQuery] string? name,
         [FromQuery] int skip = 0,
         [FromQuery] int take = 10)
     {
@@ -90,18 +90,36 @@ public class InsiderTradesController(IInsiderTradeService tradeService) : Contro
             return BadRequest(new { error = "Skip must be zero or greater." });
 
         if (take < 1 || take > MaxPageSize)
-            return BadRequest (new { error = $"Take must be between 1 and {MaxPageSize}." });
-
-        var trades = (await tradeService.GetInsiderTradesByCompany(name, skip, take)).ToList();
-
-        if (trades.Count == 0)
+            return BadRequest(new { error = $"Take must be between 1 and {MaxPageSize}." });
+        if (!string.IsNullOrWhiteSpace(symbol))
         {
-            return NotFound(new { error = $"No trades found for company: {name}" });
+            var trades = (await tradeService.GetInsiderTradesByCompany(symbol, skip, take)).ToList();
+            
+            if (trades.Count == 0)
+            {
+                return NotFound(new
+                {
+                    error = $"No insider trades found for symbol {symbol}."
+                });
+            }
+
+            return Ok(trades.Select(t => t.ToListDto()));
         }
 
-        var dtos = trades.Select(t => t.ToListDto());
+        if (!string.IsNullOrWhiteSpace(name))
+        {
+            logger.LogWarning(
+                "Deprecated ?name= parameter used on /api/InsiderTrades/company (name='{Name}').", name);
 
-        return Ok(dtos);
+            var trades = (await tradeService.GetInsiderTradesByCompany(name, skip, take)).ToList();
+
+            if (trades.Count == 0)
+                return NotFound(new { error = $"No trades found for company: {name}" });
+
+            return Ok(trades.Select(t => t.ToListDto()));
+        }
+
+        return BadRequest(new { error = "Either 'symbol' or 'name' query parameter is required." });
     }
 
     [HttpGet("ytd-stats")]

--- a/src/AktieKoll/Extensions/StringExtensions.cs
+++ b/src/AktieKoll/Extensions/StringExtensions.cs
@@ -7,6 +7,12 @@ public static partial class StringExtensions
     [GeneratedRegex(@"\s*\(publ\)", RegexOptions.IgnoreCase)]
     private static partial Regex PublRegex();
 
+    [GeneratedRegex(@"\bAktiebolaget\b", RegexOptions.IgnoreCase)]
+    private static partial Regex AktiebolagetRegex();
+
+    [GeneratedRegex(@"\bgroup\b", RegexOptions.IgnoreCase)]
+    private static partial Regex GroupRegex();
+
     [GeneratedRegex(@"\s*\bAB\b", RegexOptions.IgnoreCase)]
     private static partial Regex AbRegex();
 
@@ -54,6 +60,12 @@ public static partial class StringExtensions
 
         // Remove (publ)
         result = PublRegex().Replace(result, "");
+
+        // Expand "Aktiebolaget" → "AB" so the next step strips it
+        result = AktiebolagetRegex().Replace(result, "AB");
+
+        //Remove Group
+        result = GroupRegex().Replace(result, "");
 
         // Remove AB
         result = AbRegex().Replace(result, "");

--- a/src/AktieKoll/Interfaces/IInsiderTrades.cs
+++ b/src/AktieKoll/Interfaces/IInsiderTrades.cs
@@ -10,5 +10,6 @@ public interface IInsiderTradeService
     Task<IEnumerable<CompanyTransactionStats>> GetTransactionCountBuy(string? companyName = null, int days = 30, int? top = 5);
     Task<IEnumerable<CompanyTransactionStats>> GetTransactionCountSell(string? companyName = null, int days = 30, int? top = 5);
     Task<IEnumerable<InsiderTrade>> GetInsiderTradesByCompany(string companyName, int skip = 0, int take = 10);
+    Task<IEnumerable<InsiderTrade>> GetInsiderTradesBySymbol(string symbol, int skip = 0, int take = 10);
     Task<YtdStats> GetYtdTransactionStatsAsync();
 }

--- a/src/AktieKoll/Interfaces/ISymbolService.cs
+++ b/src/AktieKoll/Interfaces/ISymbolService.cs
@@ -5,4 +5,6 @@ namespace AktieKoll.Interfaces;
 public interface ISymbolService
 {
     Task ResolveSymbolsAsync(List<InsiderTrade> trades);
+    Task<string?> ResolveSymbolAsync(string? companyName, string? isin);
+    void InvalidateCache();
 }

--- a/src/AktieKoll/Services/InsiderTradeService.cs
+++ b/src/AktieKoll/Services/InsiderTradeService.cs
@@ -7,7 +7,12 @@ using Microsoft.Extensions.Caching.Memory;
 
 namespace AktieKoll.Services;
 
-public class InsiderTradeService(ApplicationDbContext context, ISymbolService symbolService, IMemoryCache cache, TimeProvider timeProvider) : IInsiderTradeService
+public class InsiderTradeService(
+    ApplicationDbContext context,
+    ISymbolService symbolService, 
+    IMemoryCache cache,
+    TimeProvider timeProvider,
+    ILogger<InsiderTradeService> logger) : IInsiderTradeService
 {
     public async Task<string> AddInsiderTrades(List<InsiderTrade> insiderTrades)
     {
@@ -43,6 +48,13 @@ public class InsiderTradeService(ApplicationDbContext context, ISymbolService sy
             if (duplicate != null)
             {
                 continue;
+            }
+
+            if (string.IsNullOrEmpty(trade.Symbol)) 
+            {
+                logger.LogWarning(
+                    "Trade unresolved at ingestion - CompanyName: '{Company}', ISIN: '{Isin}'",
+                    trade.CompanyName, trade.Isin ?? "none");
             }
 
             context.InsiderTrades.Add(trade);
@@ -134,6 +146,21 @@ public class InsiderTradeService(ApplicationDbContext context, ISymbolService sy
 
         return await context.InsiderTrades
             .Where(t => t.CompanyName.ToLower() == filteredCompanyName)
+            .OrderByDescending(t => t.PublishingDate)
+            .Skip(skip)
+            .Take(take)
+            .ToListAsync();
+    }
+
+    public async Task<IEnumerable<InsiderTrade>> GetInsiderTradesBySymbol(string symbol, int skip = 0, int take = 10)
+    {
+        if (string.IsNullOrWhiteSpace(symbol))
+        {
+            return [];
+        }
+
+        return await context.InsiderTrades
+            .Where(t => t.Symbol == symbol)
             .OrderByDescending(t => t.PublishingDate)
             .Skip(skip)
             .Take(take)

--- a/src/AktieKoll/Services/SymbolService.cs
+++ b/src/AktieKoll/Services/SymbolService.cs
@@ -1,155 +1,166 @@
 ﻿using AktieKoll.Data;
+using AktieKoll.Extensions;
 using AktieKoll.Interfaces;
 using AktieKoll.Models;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace AktieKoll.Services;
 
-public class SymbolService(ApplicationDbContext context, ILogger<SymbolService> logger) : ISymbolService
+public class SymbolService(
+    ApplicationDbContext context,
+    IMemoryCache cache,
+    ILogger<SymbolService> logger) : ISymbolService
 {
+    private const string CacheKey = "companies:symbol-cache";
+
+    private record CachedEntry(string Code, string? Isin, string NormalizedIsin, string NormalizedName);
+
+    public void InvalidateCache() => cache.Remove(CacheKey);
+
+    public async Task<string?> ResolveSymbolAsync(string? companyName, string? isin)
+    {
+        var companies = await GetCachedCompaniesAsync();
+        return Resolve(companyName, isin, companies);
+    }
+
     public async Task ResolveSymbolsAsync(List<InsiderTrade> trades)
     {
-        var tradesWithIsin = trades
-        .Where(t => !string.IsNullOrEmpty(t.Isin) && string.IsNullOrEmpty(t.Symbol))
-        .ToList();
+        var pending = trades.Where(t => string.IsNullOrEmpty(t.Symbol)).ToList();
+        if (pending.Count == 0) return;
 
-        var tradesWithoutIsin = trades
-            .Where(t => string.IsNullOrEmpty(t.Isin) && string.IsNullOrEmpty(t.Symbol))
-            .ToList();
+        logger.LogInformation("Resolving symbols for {Count} trades", pending.Count);
 
-        logger.LogInformation("Resolving symbols for {WithIsin} trades with ISIN, {WithoutIsin} without ISIN",
-            tradesWithIsin.Count, tradesWithoutIsin.Count);
+        var companies = await GetCachedCompaniesAsync();
 
-        // Step 1: Resolve by ISIN (for trades that have ISINs)
-        Dictionary<string, string> companiesByIsin = [];
+        int byIsin = 0, byName = 0, notFound = 0;
 
-        if (tradesWithIsin.Count > 0)
+        foreach (var trade in pending)
         {
-            var uniqueIsins = tradesWithIsin
-                .Select(t => t.Isin!)
-                .Distinct()
-                .ToList();
-
-            companiesByIsin = await context.Companies
-                .Where(c => c.Isin != null && uniqueIsins.Contains(c.Isin))
-                .ToDictionaryAsync(c => c.Isin!, c => c.Code);
-        }
-
-        // Step 2: Build name fallback for unresolved trades (with OR without ISIN)
-        var unresolvedTrades = trades
-            .Where(t => string.IsNullOrEmpty(t.Symbol))
-            .Where(t => string.IsNullOrEmpty(t.Isin) || !companiesByIsin.ContainsKey(t.Isin))
-            .ToList();
-
-        Dictionary<string, string> companiesByName = [];
-
-        if (unresolvedTrades.Count > 0)
-        {
-            var normalizedNames = unresolvedTrades
-                .Select(t => NormalizeCompanyName(t.CompanyName))
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToList();
-
-            logger.LogInformation("Attempting name fallback for {Count} companies", normalizedNames.Count);
-
-            var allCompanies = await context.Companies
-                .Select(c => new { c.Name, c.Code })
-                .ToListAsync();
-
-            companiesByName = allCompanies
-                .GroupBy(c => NormalizeCompanyName(c.Name))
-                .Where(g => normalizedNames.Contains(g.Key, StringComparer.OrdinalIgnoreCase))
-                .ToDictionary(
-                    g => g.Key,
-                    g => PickBestTicker(g.Select(x => x.Code).ToList()),
-                    StringComparer.OrdinalIgnoreCase);
-        }
-
-        // Step 3: Assign symbols
-        int resolvedByIsin = 0;
-        int resolvedByName = 0;
-        int notFound = 0;
-
-        foreach (var trade in trades)
-        {
-            if (!string.IsNullOrEmpty(trade.Symbol))
-                continue;
-
-            // Try ISIN first (if trade has ISIN)
-            if (!string.IsNullOrEmpty(trade.Isin) &&
-                companiesByIsin.TryGetValue(trade.Isin, out var codeByIsin))
+            var symbol = Resolve(trade.CompanyName, trade.Isin, companies);
+            if (symbol != null)
             {
-                trade.Symbol = codeByIsin;
-                resolvedByIsin++;
+                trade.Symbol = symbol;
+                // Track rough breakdown for the log summary
+                if (!string.IsNullOrWhiteSpace(trade.Isin) &&
+                    companies.Any(c => c.Isin == trade.Isin || NormalizeIsin(c.Isin) == NormalizeIsin(trade.Isin)))
+                    byIsin++;
+                else
+                    byName++;
             }
-            // Fallback to name
             else
             {
-                var normalizedName = NormalizeCompanyName(trade.CompanyName);
-
-                if (companiesByName.TryGetValue(normalizedName, out var codeByName))
-                {
-                    trade.Symbol = codeByName;
-                    resolvedByName++;
-                    logger.LogInformation("Resolved by name: '{Original}' → '{Normalized}' → {Symbol}",
-                        trade.CompanyName, normalizedName, codeByName);
-                }
-                else
-                {
-                    logger.LogWarning("No symbol found - ISIN: '{Isin}', Company: '{Company}' (normalized: '{Normalized}')",
-                        trade.Isin ?? "none", trade.CompanyName, normalizedName);
-                    notFound++;
-                }
+                logger.LogWarning(
+                    "No symbol found — CompanyName: '{Company}', ISIN: '{Isin}'",
+                    trade.CompanyName, trade.Isin ?? "none");
+                notFound++;
             }
         }
 
         logger.LogInformation(
-            "Symbol resolution complete: {ResolvedByIsin} by ISIN, {ResolvedByName} by name, {NotFound} not found",
-            resolvedByIsin, resolvedByName, notFound);
+            "Symbol resolution complete: ~{ByIsin} by ISIN, ~{ByName} by name, {NotFound} not found",
+            byIsin, byName, notFound);
     }
 
-    private static string NormalizeCompanyName(string name)
-    {
-        if (string.IsNullOrWhiteSpace(name))
-            return string.Empty;
+    // ── Core resolution logic (single trade) ─────────────────────────────────
 
-         return name
-            .Trim()
-            .TrimEnd('.', ',', ';')
-            .Replace(" AB", "", StringComparison.OrdinalIgnoreCase)
-            .Replace("AB ", "", StringComparison.OrdinalIgnoreCase)
-            .Replace(" (publ)", "", StringComparison.OrdinalIgnoreCase)
-            .Replace("(publ)", "", StringComparison.OrdinalIgnoreCase)
-            .Replace(" Series A", "", StringComparison.OrdinalIgnoreCase)
-            .Replace(" Series B", "", StringComparison.OrdinalIgnoreCase)
-            .Replace(" A", "", StringComparison.OrdinalIgnoreCase)
-            .Replace(" B", "", StringComparison.OrdinalIgnoreCase)
-            .Trim()
-            .Replace("  ", " ");
+    private string? Resolve(string? companyName, string? isin, List<CachedEntry> companies)
+    {
+        // 1. ISIN exact match
+        if (!string.IsNullOrWhiteSpace(isin))
+        {
+            var exactIsin = companies.Where(c => c.Isin == isin).ToList();
+            if (exactIsin.Count > 0)
+                return PickBestTicker(exactIsin.Select(c => c.Code));
+
+            // 2. ISIN fuzzy (strip spaces, dashes, uppercase)
+            var normIsin = NormalizeIsin(isin);
+            if (!string.IsNullOrEmpty(normIsin))
+            {
+                var fuzzyIsin = companies.Where(c => c.NormalizedIsin == normIsin).ToList();
+                if (fuzzyIsin.Count > 0)
+                    return PickBestTicker(fuzzyIsin.Select(c => c.Code));
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(companyName))
+        {
+            var normName = companyName.FilterCompanyName().ToLower();
+
+            // 3. Name normalised exact match
+            var exactName = companies.Where(c => c.NormalizedName == normName).ToList();
+            if (exactName.Count > 0)
+                return PickBestTicker(exactName.Select(c => c.Code));
+
+            // 4. Jaccard token similarity ≥ 0.8
+            var best = companies
+                .Select(c => (c, sim: JaccardTokenSimilarity(normName, c.NormalizedName)))
+                .Where(x => x.sim >= 0.8)
+                .OrderByDescending(x => x.sim)
+                .ToList();
+
+            if (best.Count > 0)
+            {
+                var topSim = best[0].sim;
+                var topCodes = best.Where(x => x.sim == topSim).Select(x => x.c.Code);
+                logger.LogDebug("Fuzzy match: '{Name}' → sim={Sim:F2}", companyName, topSim);
+                return PickBestTicker(topCodes);
+            }
+        }
+
+        return null;
     }
 
-    private static string PickBestTicker(List<string> tickers)
+    // ── Cache ─────────────────────────────────────────────────────────────────
+
+    private async Task<List<CachedEntry>> GetCachedCompaniesAsync()
     {
-        if (tickers.Count == 1)
-            return tickers[0];
+        if (cache.TryGetValue(CacheKey, out List<CachedEntry>? cached) && cached != null)
+            return cached;
 
-        // Priority order:
-        // 1. B-shares (most liquid in Sweden)
-        var bShare = tickers.FirstOrDefault(t => t.EndsWith("-B"));
-        if (bShare != null)
-            return bShare;
+        logger.LogInformation("Loading companies into symbol cache");
 
-        // 2. A-shares
-        var aShare = tickers.FirstOrDefault(t => t.EndsWith("-A"));
-        if (aShare != null)
-            return aShare;
+        var companies = await context.Companies
+            .Select(c => new { c.Code, c.Isin, c.Name })
+            .ToListAsync();
 
-        // 3. No suffix (single share class)
-        var noSuffix = tickers.FirstOrDefault(t => !t.Contains('-'));
-        if (noSuffix != null)
-            return noSuffix;
+        var entries = companies.Select(c => new CachedEntry(
+            c.Code,
+            c.Isin,
+            NormalizeIsin(c.Isin),
+            (c.Name ?? string.Empty).FilterCompanyName().ToLower()
+        )).ToList();
 
-        // 4. Fallback to first
-        return tickers[0];
+        cache.Set(CacheKey, entries);
+        return entries;
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static string NormalizeIsin(string? isin) =>
+        isin?.Replace(" ", "").Replace("-", "").ToUpperInvariant() ?? string.Empty;
+
+    private static double JaccardTokenSimilarity(string a, string b)
+    {
+        if (string.IsNullOrEmpty(a) || string.IsNullOrEmpty(b)) return 0.0;
+
+        var tokensA = new HashSet<string>(a.Split(' ', StringSplitOptions.RemoveEmptyEntries));
+        var tokensB = new HashSet<string>(b.Split(' ', StringSplitOptions.RemoveEmptyEntries));
+
+        var intersection = tokensA.Intersect(tokensB).Count();
+        var union = tokensA.Union(tokensB).Count();
+
+        return union == 0 ? 0.0 : (double)intersection / union;
+    }
+
+    private static string PickBestTicker(IEnumerable<string> tickers)
+    {
+        var list = tickers.ToList();
+        if (list.Count == 1) return list[0];
+
+        return list.FirstOrDefault(t => t.EndsWith("-B"))
+            ?? list.FirstOrDefault(t => t.EndsWith("-A"))
+            ?? list.FirstOrDefault(t => !t.Contains('-'))
+            ?? list[0];
     }
 }

--- a/src/FetchCompanies/Program.cs
+++ b/src/FetchCompanies/Program.cs
@@ -74,7 +74,7 @@ foreach (var eod in incomingCompanies)
     if (existingByCode.TryGetValue(eod.Code, out var existing))
     {
         existing.Name = eod.Name;
-        existing.Isin = eod.Isin;
+        existing.Isin = eod.Isin ?? existing.Isin;
         existing.Currency = eod.Currency;
         existing.Type = eod.Type;
         existing.LastUpdated = DateTime.UtcNow;


### PR DESCRIPTION
### Changes
- `SymbolService` rebuilt with `IMemoryCache`, Jaccard fuzzy matching and `PickBestTicker` B-share preference
- `/api/InsiderTrades/company` now accepts `?symbol=` with deprecated `?name=` kept for backwards compatibility
- `FilterCompanyName` strips `Aktiebolaget` and `Group` suffixes
- `FetchCompanies` no longer overwrites existing ISIN with null (`eod.Isin ?? existing.Isin`)
- Tests updated for new `SymbolService` constructor signature