### PR TITLE
Fix CodeQL security vulnerabilities: log injection, PII exposure, wor…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
       - main
       - develop
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/cron-fetch.yml
+++ b/.github/workflows/cron-fetch.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "0 */6 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   fetch:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-companies.yml
+++ b/.github/workflows/update-companies.yml
@@ -5,7 +5,10 @@ on:
   schedule:
     - cron: '0 0 1 * *' # Monthly
 
-jobs: 
+permissions:
+  contents: read
+
+jobs:
   update-companies:
     runs-on: ubuntu-latest
 

--- a/src/AktieKoll/Controllers/InsiderTradesController.cs
+++ b/src/AktieKoll/Controllers/InsiderTradesController.cs
@@ -105,10 +105,7 @@ public class InsiderTradesController(IInsiderTradeService tradeService, ILogger<
 
         if (!string.IsNullOrWhiteSpace(name))
         {
-            var safeName = name.Replace("\r", "", StringComparison.Ordinal)
-                               .Replace("\n", "", StringComparison.Ordinal);
-            logger.LogWarning(
-                "Deprecated ?name= parameter used on /api/InsiderTrades/company (name='{Name}').", safeName);
+            logger.LogWarning("Deprecated ?name= parameter used on /api/InsiderTrades/company.");
 
             var trades = (await tradeService.GetInsiderTradesByCompany(name, skip, take)).ToList();
 

--- a/src/AktieKoll/Controllers/InsiderTradesController.cs
+++ b/src/AktieKoll/Controllers/InsiderTradesController.cs
@@ -105,8 +105,10 @@ public class InsiderTradesController(IInsiderTradeService tradeService, ILogger<
 
         if (!string.IsNullOrWhiteSpace(name))
         {
+            var safeName = name.Replace("\r", "", StringComparison.Ordinal)
+                               .Replace("\n", "", StringComparison.Ordinal);
             logger.LogWarning(
-                "Deprecated ?name= parameter used on /api/InsiderTrades/company (name='{Name}').", name);
+                "Deprecated ?name= parameter used on /api/InsiderTrades/company (name='{Name}').", safeName);
 
             var trades = (await tradeService.GetInsiderTradesByCompany(name, skip, take)).ToList();
 

--- a/src/AktieKoll/Program.cs
+++ b/src/AktieKoll/Program.cs
@@ -155,6 +155,9 @@ builder.Services.AddScoped<IEmailService,    EmailService>();
 
 builder.Services.AddHttpClient<CsvFetchService>();
 builder.Services.AddHttpClient<IDiscordService, DiscordService>();
+
+// Suppress HttpClient request/response URL logging to prevent Discord webhook URLs from appearing in logs
+builder.Logging.AddFilter("System.Net.Http.HttpClient", LogLevel.Warning);
 builder.Services.AddScoped<INotificationService, NotificationService>();
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddTransient<ISymbolService, SymbolService>();

--- a/src/AktieKoll/Services/CsvFetchService.cs
+++ b/src/AktieKoll/Services/CsvFetchService.cs
@@ -21,7 +21,6 @@ public class CsvFetchService(HttpClient httpClient, Func<TextReader, CsvReader> 
         var url = $"https://marknadssok.fi.se/Publiceringsklient/sv-SE/Search/Search?SearchFunctionType=Insyn&Utgivare=&PersonILedandeSt%C3%A4llningNamn=&Transaktionsdatum.From=&Transaktionsdatum.To=&Publiceringsdatum.From={Uri.EscapeDataString(fromDateString)}&Publiceringsdatum.To={Uri.EscapeDataString(toDateString)}&button=export&Page=1";
 
         logger.LogInformation("Fetching insider trades from {From} to {To}", fromDateString, toDateString);
-        logger.LogDebug("Request URL: {Url}", url);
         try
         {
             using var stream = await httpClient.GetStreamAsync(url);

--- a/src/AktieKoll/Services/DiscordService.cs
+++ b/src/AktieKoll/Services/DiscordService.cs
@@ -71,7 +71,7 @@ public class DiscordService(HttpClient httpClient, IConfiguration config, ILogge
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Discord webhook failed for company {Code}", companyCode);
+            logger.LogError("Discord webhook request failed for company {Code}: {ExceptionType}", companyCode, ex.GetType().Name);
             return false;
         }
     }

--- a/src/AktieKoll/Services/EmailService.cs
+++ b/src/AktieKoll/Services/EmailService.cs
@@ -252,13 +252,7 @@ public class EmailService(IConfiguration config, ILogger<EmailService> logger) :
         }
         catch (Exception ex)
         {
-            var atIdx = toEmail.IndexOf('@');
-            var maskedEmail = atIdx > 0
-                ? toEmail[0] + "***" + toEmail[atIdx..]
-                : "***";
-            var safeSubject = subject.Replace("\r", "", StringComparison.Ordinal)
-                                     .Replace("\n", "", StringComparison.Ordinal);
-            logger.LogError(ex, "Failed to send email to {Email} with subject '{Subject}'", maskedEmail, safeSubject);
+            logger.LogError(ex, "Failed to send email.");
             throw;
         }
     }

--- a/src/AktieKoll/Services/EmailService.cs
+++ b/src/AktieKoll/Services/EmailService.cs
@@ -252,7 +252,13 @@ public class EmailService(IConfiguration config, ILogger<EmailService> logger) :
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to send email to {Email} with subject '{Subject}'", toEmail, subject);
+            var atIdx = toEmail.IndexOf('@');
+            var maskedEmail = atIdx > 0
+                ? toEmail[0] + "***" + toEmail[atIdx..]
+                : "***";
+            var safeSubject = subject.Replace("\r", "", StringComparison.Ordinal)
+                                     .Replace("\n", "", StringComparison.Ordinal);
+            logger.LogError(ex, "Failed to send email to {Email} with subject '{Subject}'", maskedEmail, safeSubject);
             throw;
         }
     }

--- a/src/FetchTrades/Program.cs
+++ b/src/FetchTrades/Program.cs
@@ -20,6 +20,9 @@ if (string.IsNullOrWhiteSpace(connectionString))
 // Build host with DI
 var builder = Host.CreateApplicationBuilder(args);
 
+// Suppress HttpClient request/response URL logging to avoid leaking webhook URLs and tokens in CI logs
+builder.Logging.AddFilter("System.Net.Http.HttpClient", LogLevel.Warning);
+
 // Database
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseNpgsql(connectionString));


### PR DESCRIPTION
workflow permissions

- Sanitize user-supplied `name` query param before logging in InsiderTradesController to prevent log injection (cs/log-forging)
- Mask email address (u***@domain) and sanitize subject before logging in EmailService to prevent log injection and PII exposure in logs (cs/exposure-of-sensitive-information)
- Add `permissions: contents: read` to ci.yml, cron-fetch.yml, and update-companies.yml to enforce least-privilege for GITHUB_TOKEN (actions/missing-workflow-permissions)
