### PR TITLE
fix: forward X-Forwarded-Host so token exchange redirect_uri matches

### DIFF
--- a/src/AktieKoll/Program.cs
+++ b/src/AktieKoll/Program.cs
@@ -33,7 +33,7 @@ builder.Services.AddCors(options =>
 
 builder.Services.Configure<ForwardedHeadersOptions>(options =>
 {
-    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+    options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost;
     options.KnownIPNetworks.Clear();
     options.KnownProxies.Clear();
 });


### PR DESCRIPTION
The Google middleware builds redirect_uri for the token exchange from Request.Host, which was still the Azure backend domain. Enabling XForwardedHost forwarding lets the proxy pass www.aktiekoll.com as the host, so both the authorization URL and token exchange use the correct proxy URL and Google accepts the code exchange.